### PR TITLE
v0.1.4 export chat button in the header and settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+## [0.1.4] - Current Version
 
-## [0.1.3] - Current Version
+- Added quick export button to chat header and export button to the History tab in the Settings for chat export functionality
+- Button uses the export format currently selected in Settings 
+- Supported export formats:
+  - Markdown `.md`
+  - json `.json`
+
+## [0.1.3]
 
 - Implemented system prompt management and selection feature
   - Save, edit, and delete multiple system prompts in settings

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A lightweight, browser-based chat interface for interacting with various AI prov
 
 ## Features
 
-- **Quick Export Access**: Export current chat directly from header with one click
+- **Quick Export Access**: Export current chat directly from header with one click or from the History tab in Settings
 - **Multi-Provider Support**: Connect to various AI services including Groq, OpenAI, Anthropic, Mistral, xAI, DeepSeek, Novita, OpenRouter, and local Ollama instances
 - **Local-First Architecture**: All chat history and settings stored securely in your browser
 - **Progressive Web App (PWA)**: Installable for an app-like experience with basic offline access
@@ -106,6 +106,23 @@ To manage system prompts:
 - **Rename a Chat**: Click the pencil icon next to a chat in the sidebar
 - **Delete a Chat**: Click the trash icon next to a chat
 - **Clear All History**: Go to Settings > History tab > "Clear All History"
+- **Export Chat**: Go to Settings > History tab > "Export Chat"
+
+### Advanced Features
+- **Regenerate Response**: Click the regenerate icon next to a message
+- **Copy Message**: Click the copy icon next to a message. Format options can be set in the Settings -> General:
+  - Markdown
+  - Plain Text
+- **Information about Response**: Mouse hover over the info icon next to a message. You will see the technical details of the response.
+```text
+Provider: <Provider name>
+Model: <model name>
+Duration: <mumber in seconds>
+Prompt Tokens: <number>
+Completion Tokens: <number>
+Total Tokens: <number>
+Speed (tokens/sec): <number>
+```
 
 ## Security Note
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A lightweight, browser-based chat interface for interacting with various AI prov
 
 ## Features
 
+- **Quick Export Access**: Export current chat directly from header with one click
 - **Multi-Provider Support**: Connect to various AI services including Groq, OpenAI, Anthropic, Mistral, xAI, DeepSeek, Novita, OpenRouter, and local Ollama instances
 - **Local-First Architecture**: All chat history and settings stored securely in your browser
 - **Progressive Web App (PWA)**: Installable for an app-like experience with basic offline access

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
                 <div id="chat-model-display-container">
                     <span id="chat-current-provider-model">No Model Selected</span>
                 </div>
+                <button id="header-export-chat-btn" class="btn icon-btn" title="Export Current Chat"><i class="fas fa-file-export"></i></button>
                 <button id="toggle-right-sidebar-btn" class="btn icon-btn" title="Toggle Parameters"><i
                         class="fas fa-sliders-h"></i></button>
             </header>
@@ -201,8 +202,16 @@
                 <div id="history-settings" class="tab-content">
                     <h3>History Management</h3>
                     <p>Manage your chat history here.</p>
-                    <button id="export-history-btn" class="btn" title="Feature for future version"><i
-                            class="fas fa-download"></i> Export All History (Not Implemented)</button>
+                    <div class="form-group">
+                        <label for="export-chat-format">Export Current Chat Format:</label>
+                        <select id="export-chat-format">
+                            <option value="markdown" selected>Markdown (.md)</option>
+                            <option value="json">JSON (.json)</option>
+                        </select>
+                    </div>
+                    <button id="export-current-chat-btn" class="btn"><i class="fas fa-download"></i> Export Current Chat</button>
+                    <!-- <button id="export-history-btn" class="btn" title="Feature for future version"><i
+                            class="fas fa-download"></i> Export All History (Not Implemented)</button> -->
                     <button id="clear-all-history-btn" class="btn btn-danger"><i class="fas fa-trash-alt"></i> Clear All
                         History</button>
                     <div id="settings-chat-list-container">

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
                     <h3>About GrokChat</h3>
                     <p>GrokChat is an open-source project. You can find the source code and contribute on <a
                             href="http://github.com/OleksiyM/grokchat" target="_blank">GitHub</a>.</p>
-                    <p>Version: 0.1.3</p>
+                    <p>Version: 0.1.4</p>
                 </div>
 
             </div>

--- a/style.css
+++ b/style.css
@@ -309,6 +309,14 @@ html.dark-theme #chat-list li:hover {
     opacity: 0.8;
 }
 
+#chat-header #header-export-chat-btn {
+    margin-right: 0px; /* Remove or set to 0 */
+}
+
+#chat-header #toggle-right-sidebar-btn {
+    margin-left: 4px; /* Adjust this value as needed for desired closeness */
+}
+
 
 #message-area-wrapper {
     flex-grow: 1;
@@ -1084,4 +1092,16 @@ html.dark-theme .message-actions button:hover {
     justify-content: flex-end;
     gap: 10px;
     margin-top: 15px;
+}
+
+/* Export History Styles */
+#history-settings .form-group {
+    margin-bottom: 15px; /* Add some space below the dropdown group */
+}
+
+#export-current-chat-btn {
+    margin-top: 10px; /* Add some space above the button */
+    /* Assuming .btn class handles most styling. Full width if needed: */
+    /* width: 100%; */
+    /* box-sizing: border-box; */
 }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'grokchat-cache-v0.1.3';
+const CACHE_NAME = 'grokchat-cache-v0.1.4';
 const urlsToCache = [
   '/',
   '/index.html',


### PR DESCRIPTION
This commit adds an "Export Current Chat" button directly to the main chat header, appearing to the left of the "Toggle Parameters" button. Also export button was added to the History tab on the Settings

This provides you with quicker access to the chat export functionality.

Key changes:
- Added a new export icon button (`#header-export-chat-btn`) to `index.html` within the `chat-header`.
- Updated `script.js` to cache this new button and add an event listener.
  - Clicking the button triggers the existing `handleExportChat` function.
  - It uses the export format currently selected in the Settings modal.
  - An error is shown if no chat is active.
- Adjusted `style.css` to ensure the new button is correctly spaced and styled in the header.
- [update readme with export and advanced features](https://github.com/OleksiyM/grokchat/commit/464077fbe17cd5d00cfc0e4ed26ce3ade327aa55)