### PR TITLE
Fix/message edit UI improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## [0.1.10] Current Version
+## [0.1.11] Current version
+
+- UI Improvements:
+   - Enhanced message edit window sizing and responsive behavior
+   - Styled "edited" indicator with theme-adaptive colors
+   - Improved message action button spacing 
+
+## [0.1.10] 
 
 - Added in-place message editing:
   - Edit messages directly within the chat interface.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![GrokChat Logo](https://img.shields.io/badge/GrokChat-Web%20Client-blue)](https://grokchat.pages.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.1.10-orange)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.1.11-orange)](CHANGELOG.md)
 
 </div>
 

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
                     <h3>About GrokChat</h3>
                     <p>GrokChat is an open-source project. You can find the source code and contribute on <a
                             href="http://github.com/OleksiyM/grokchat" target="_blank">GitHub</a>.</p>
-                    <p>Version: 0.1.10</p>
+                    <p>Version: 0.1.11</p>
                 </div>
 
             </div>

--- a/style.css
+++ b/style.css
@@ -395,6 +395,14 @@ html.dark-theme .message.error {
     text-align: right;
 }
 
+.message .timestamp .edited-label {
+    font-style: italic;
+    opacity: 0.8;
+    font-size: 0.9em; /* Slightly smaller than the parent timestamp's font-size */
+    /* margin-right: 4px; */ /* The JS already adds a space ' ' node */
+    color: var(--current-icon-color); /* Using a variable for theme adaptability */
+}
+
 .message-content p:last-child {
     margin-bottom: 0;
 }
@@ -546,6 +554,10 @@ html.dark-theme .message.error {
     cursor: pointer;
     display: inline-flex; /* Allow icon and text to align */
     align-items: center;
+}
+
+.message-actions button i {
+    margin-right: 5px; /* Space between icon and text */
 }
 
 .message-actions button:hover {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'grokchat-cache-v0.1.10';
+const CACHE_NAME = 'grokchat-cache-v0.1.11';
 const urlsToCache = [
   '/',
   '/index.html',


### PR DESCRIPTION
Fix: Improve message editing UI and related elements

This commit addresses several UI issues related to message editing and display:

1.  **Edit Window Sizing**:
    - Ensures the message edit textarea correctly matches the message's width.
    - When editing starts, the message bubble's width is dynamically adjusted to be at least its original width or the minimum width of the textarea (plus the bubble's padding/borders), whichever is greater. This prevents the textarea from overflowing the bubble for short messages and avoids the bubble shrinking for long messages.
    - The textarea remains manually resizable (`resize: both`).
    - Inline styles for width are properly cleaned up after editing.

2.  **"edited" Label**:
    - The "edited" indicator next to the timestamp is now a styled `<span>` (italic, slightly smaller, theme-adaptive color) instead of raw text with a pipe separator, improving its visual appeal.

3.  **Message Action Button Spacing**:
    - Added a small right margin to icons within message action buttons (e.g., "Edit", "Copy") to ensure proper spacing between the icon and the button text.