### PR TITLE
Hide chat title and model provider in header on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1305,6 +1305,11 @@ html.dark-theme .message-actions button:hover {
     .message {
         max-width: 95%;
     }
+
+    #chat-title-display,
+    #chat-current-provider-model {
+        display: none;
+    }
 }
 
 /* Scrollbar Styling (Optional, Webkit specific) */


### PR DESCRIPTION
Hide chat title and model provider in header on mobile