### PR TITLE
feat: Add 'Copy current chat' button and functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
                 <div id="chat-model-display-container">
                     <span id="chat-current-provider-model">No Model Selected</span>
                 </div>
+                <button id="header-copy-chat-btn" class="btn icon-btn" title="Copy Current Chat"><i class="fas fa-copy"></i></button>
                 <button id="header-export-chat-btn" class="btn icon-btn" title="Export Current Chat"><i class="fas fa-file-export"></i></button>
                 <button id="toggle-right-sidebar-btn" class="btn icon-btn" title="Toggle Parameters"><i
                         class="fas fa-sliders-h"></i></button>

--- a/style.css
+++ b/style.css
@@ -529,12 +529,13 @@ html.dark-theme #folders-container .folder-item h5:hover {
     opacity: 0.8;
 }
 
+#chat-header #header-copy-chat-btn,
 #chat-header #header-export-chat-btn {
-    margin-right: 0px; /* Remove or set to 0 */
+    margin-right: 4px; /* Add a small margin to the right of copy and export buttons */
 }
 
 #chat-header #toggle-right-sidebar-btn {
-    margin-left: 4px; /* Adjust this value as needed for desired closeness */
+    /* No margin needed here if the others have margin-right */
 }
 
 


### PR DESCRIPTION
Adds a 'Copy current chat' button to the main chat header, allowing users to copy the entire chat content to the clipboard.

The format of the copied chat (Markdown or Plain Text) is determined by the 'Copy AI Message Format' setting in General Settings.

Includes:
- UI button in index.html
- Logic in script.js to handle chat retrieval, formatting, and clipboard operations.
- Minor CSS adjustments for button spacing.