### PR TITLE
Fix: Preserve folderId on chat import if folder exists

### DIFF
--- a/script.js
+++ b/script.js
@@ -770,9 +770,19 @@ const GrokChatApp = {
                         top_p: chatData.top_p,
                         isPinned: chatData.isPinned || false,
                         isArchived: chatData.isArchived || false,
-                        // folderId: chatData.folderId, // TODO: Future enhancement: map folderId to existing or new folders
-                        folderId: null, // For now, import to default/history
+                        folderId: null, // Default to null
                     };
+
+                    // Check if folderId from import exists in current settings
+                    if (chatData.folderId) {
+                        const folderExists = this.state.settings.chatFolders.some(folder => folder.id === chatData.folderId);
+                        if (folderExists) {
+                            newChat.folderId = chatData.folderId;
+                        } else {
+                            console.warn(`Folder ID "${chatData.folderId}" from import not found. Chat "${chatData.title}" will be placed in default history.`);
+                            // newChat.folderId remains null
+                        }
+                    }
 
                     const newChatId = await this.addChat(newChat);
 


### PR DESCRIPTION
Previously, all imported chats had their folderId set to null, causing chats from custom folders to be imported into the default History folder.

This change modifies the chat import logic to:
- Read the folderId property from the imported chat data.
- Check if a folder with that ID exists in the current application settings.
- If the folderId exists, assign it to the imported chat.
- If the folderId does not exist (or is not provided), the chat's folderId defaults to null, placing it in the History section.

This ensures that chats are restored to their respective custom folders if those folders (with the same IDs) are present at the time of import.